### PR TITLE
Token should now contain user group (not recommeneded in prod)

### DIFF
--- a/client/schema.json
+++ b/client/schema.json
@@ -641,6 +641,22 @@
             "deprecationReason": null
           },
           {
+            "name": "userGroup",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "email",
             "description": null,
             "args": [],

--- a/client/src/common/components/Header/Header.tsx
+++ b/client/src/common/components/Header/Header.tsx
@@ -1,14 +1,13 @@
-import { css } from 'emotion';
-import React, { useContext } from 'react';
-
 import Button from 'common/components/Button';
 import Link from 'common/components/Link';
 import Logo from 'common/components/Logo';
-import ViewerContext from 'common/components/ViewerContext';
+import { useViewer } from 'common/components/ViewerContext';
 import { linkgen, Paths } from 'common/helpers/pathing';
 import { borderColor, primaryBackgroundColor } from 'common/styles/color';
 import { breakpoints, mediaQuery } from 'common/styles/media';
 import { headerHeight } from 'common/styles/size';
+import { css } from 'emotion';
+import React from 'react';
 
 const headerClassName = css`
   width: 100%;
@@ -59,7 +58,7 @@ const logoClassName = css`
 `;
 
 const Header: React.FunctionComponent<{}> = () => {
-  const { viewer } = useContext(ViewerContext);
+  const { viewer, isDriver } = useViewer();
   return (
     <header className={headerClassName}>
       <div className={headerContentClassName}>
@@ -82,9 +81,11 @@ const Header: React.FunctionComponent<{}> = () => {
           )}
           {viewer && (
             <>
-              <Link to="/project-registration">
-                <Button variant="text">Create a project</Button>
-              </Link>
+              {isDriver && (
+                <Link to="/project-registration">
+                  <Button variant="text">Create a project</Button>
+                </Link>
+              )}
               <Link to={linkgen(Paths.dashboard)}>
                 <Button variant="text">Dashboard</Button>
               </Link>

--- a/client/src/common/components/ViewerContext/ViewerContext.tsx
+++ b/client/src/common/components/ViewerContext/ViewerContext.tsx
@@ -3,10 +3,11 @@ import {
   getViewerId,
   setViewerId
 } from 'common/helpers/sessions';
-import React from 'react';
+import React, { useContext, useMemo } from 'react';
 
 export interface Viewer {
   id: string;
+  userGroup: string | null;
 }
 export type SetViewerFn = (viewer: Viewer) => void;
 export type ClearViewerFn = () => void;
@@ -41,10 +42,12 @@ class ViewerProvider extends React.Component<ContextProps, ContextState> {
 
   componentWillMount() {
     const viewerId = getViewerId();
+    const userGroup = window.localStorage.getItem('userGroup');
 
     if (viewerId && !this.state.viewer) {
       const viewer: Viewer = {
-        id: viewerId
+        id: viewerId,
+        userGroup
       };
       this.setState({
         viewer
@@ -81,5 +84,31 @@ class ViewerProvider extends React.Component<ContextProps, ContextState> {
   }
 }
 
+interface UseViewerResult {
+  viewer: Viewer | null;
+  isDriver: boolean;
+  isSolver: boolean;
+  isLoggedIn: boolean;
+}
+const useViewer = (): UseViewerResult => {
+  const { viewer } = useContext(ViewerContext);
+  const isLoggedIn = useMemo<boolean>(() => !!viewer, [viewer]);
+  const isDriver = useMemo<boolean>(
+    () => !!viewer && !!viewer.userGroup && JSON.parse(viewer.userGroup).driver,
+    [viewer]
+  );
+  const isSolver = useMemo<boolean>(
+    () => !!viewer && !!viewer.userGroup && JSON.parse(viewer.userGroup).solver,
+    [viewer]
+  );
+
+  return {
+    viewer,
+    isLoggedIn,
+    isDriver,
+    isSolver
+  };
+};
+
 export default ViewerContext;
-export { ViewerProvider, ViewerConsumer };
+export { ViewerProvider, ViewerConsumer, useViewer };

--- a/client/src/pages/Login/LoginForm/LoginFormMutation.tsx
+++ b/client/src/pages/Login/LoginForm/LoginFormMutation.tsx
@@ -21,6 +21,7 @@ const LOGIN_MUTATION = gql`
     login(input: $input) {
       user {
         id
+        userGroup
         email
         firstName
         lastName

--- a/client/src/pages/Login/LoginForm/__generated__/Login.ts
+++ b/client/src/pages/Login/LoginForm/__generated__/Login.ts
@@ -11,6 +11,7 @@ import { LoginInput } from "./../../../../__generated__/globalTypes";
 export interface Login_login_user {
   __typename: "User";
   id: string;
+  userGroup: string;
   email: string;
   firstName: string;
   lastName: string;

--- a/client/src/pages/Login/LoginForm/functionCreators/createHandleLoginFn.ts
+++ b/client/src/pages/Login/LoginForm/functionCreators/createHandleLoginFn.ts
@@ -33,7 +33,10 @@ const createHandleLoginFn: CreateHandleLoginFn = (
       fetchResult.data.login &&
       fetchResult.data.login.user
     ) {
-      setViewer({ id: fetchResult.data.login.user.id });
+      setViewer({
+        id: fetchResult.data.login.user.id,
+        userGroup: fetchResult.data.login.user.userGroup
+      });
     } else {
       setGeneralError(
         'The email/password combination you entered is incorrect.'

--- a/client/src/pages/Signup/SignupForm/SignupFormMutation.tsx
+++ b/client/src/pages/Signup/SignupForm/SignupFormMutation.tsx
@@ -22,6 +22,7 @@ const SIGNUP_MUTATION = gql`
       user {
         id
         email
+        userGroup
         firstName
         lastName
         displayName

--- a/client/src/pages/Signup/SignupForm/__generated__/Signup.ts
+++ b/client/src/pages/Signup/SignupForm/__generated__/Signup.ts
@@ -12,6 +12,7 @@ export interface Signup_signup_user {
   __typename: "User";
   id: string;
   email: string;
+  userGroup: string;
   firstName: string;
   lastName: string;
   displayName: string | null;

--- a/client/src/pages/Signup/SignupForm/functionCreators/createHandleSignupFn.ts
+++ b/client/src/pages/Signup/SignupForm/functionCreators/createHandleSignupFn.ts
@@ -33,7 +33,8 @@ const createHandleSignupFn: CreateHandleSignupFn = (
     const result = await signup(options);
     if (result && result.data) {
       setViewer({
-        id: result.data.signup.user.id
+        id: result.data.signup.user.id,
+        userGroup: result.data.signup.user.userGroup
       });
     } else {
       setGeneralError('Unexpected error occurred!');

--- a/graphql/src/helpers/utils/jwt/options.ts
+++ b/graphql/src/helpers/utils/jwt/options.ts
@@ -2,6 +2,7 @@ export const expiresIn = 60 * 60 * 24 * 7; // equivalent of 7 days in seconds
 
 export interface JWTPayload {
   id: string;
+  userGroup: string;
 }
 
 export interface JWTObject {

--- a/graphql/src/schemas/authentication.graphql
+++ b/graphql/src/schemas/authentication.graphql
@@ -10,6 +10,7 @@ type Mutation {
 
 type User {
   id: ID!
+  userGroup: String!
   email: String!
   firstName: String!
   lastName: String!

--- a/graphql/src/web/graphql/generated/graphqlgen.ts
+++ b/graphql/src/web/graphql/generated/graphqlgen.ts
@@ -436,10 +436,18 @@ export namespace UserResolvers {
     firstName: (parent: User) => parent.firstName,
     lastName: (parent: User) => parent.lastName,
     displayName: (parent: User) =>
-      parent.displayName === undefined ? null : parent.displayName
+      parent.displayName === undefined ? null : parent.displayName,
+    userGroup: (parent: User) => parent.userGroup
   };
 
   export type IdResolver = (
+    parent: User,
+    args: {},
+    ctx: ResolverContext,
+    info: GraphQLResolveInfo
+  ) => string | Promise<string>;
+
+  export type UserGroupResolver = (
     parent: User,
     args: {},
     ctx: ResolverContext,
@@ -476,6 +484,13 @@ export namespace UserResolvers {
 
   export interface Type {
     id: (
+      parent: User,
+      args: {},
+      ctx: ResolverContext,
+      info: GraphQLResolveInfo
+    ) => string | Promise<string>;
+
+    userGroup: (
       parent: User,
       args: {},
       ctx: ResolverContext,

--- a/graphql/src/web/graphql/models.ts
+++ b/graphql/src/web/graphql/models.ts
@@ -4,6 +4,7 @@ export interface User {
   firstName: string;
   lastName: string;
   displayName?: string;
+  userGroup: string;
 }
 
 export interface SignupPayload {

--- a/graphql/src/web/graphql/resolvers/mutations/login/login.ts
+++ b/graphql/src/web/graphql/resolvers/mutations/login/login.ts
@@ -23,7 +23,8 @@ const login: MutationResolvers.LoginResolver = async (parent, args, ctx) => {
 
   try {
     const token = ctx.utils.jwt.sign({
-      id: user.id
+      id: user.id,
+      userGroup: user.userGroup
     });
     ctx.utils.headers.setTokenToResponse(ctx.response, token);
   } catch (e) {

--- a/graphql/src/web/graphql/resolvers/mutations/signup/signup.ts
+++ b/graphql/src/web/graphql/resolvers/mutations/signup/signup.ts
@@ -27,7 +27,8 @@ const signup: MutationResolvers.SignupResolver = async (parent, args, ctx) => {
 
   try {
     const token = ctx.utils.jwt.sign({
-      id: newUser.id
+      id: newUser.id,
+      userGroup: newUser.userGroup
     });
     ctx.utils.headers.setTokenToResponse(ctx.response, token);
   } catch (e) {
@@ -40,7 +41,8 @@ const signup: MutationResolvers.SignupResolver = async (parent, args, ctx) => {
       firstName: newUser.firstName,
       lastName: newUser.lastName,
       email: newUser.email,
-      displayName: newUser.displayName
+      displayName: newUser.displayName,
+      userGroup: newUser.userGroup
     }
   };
 };


### PR DESCRIPTION
Send user group as part of JWT token. This is loaded into the app when the page loads. However, this could be a problem in the future where the `userGroup` changes and token does not expire. 

For now, its ok to get it rolling